### PR TITLE
config: add flake8 configuration for project linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+per-file-ignores = 
+    tests/*:E402
+exclude = 
+    .git,
+    __pycache__,
+    .pytest_cache,
+    build,
+    dist,
+    *.egg-info


### PR DESCRIPTION
- Set max line length to 100 characters for readability
- Ignore E203 and W503 for black formatter compatibility
- Allow E402 in test files for sys.path manipulation
- Exclude build directories and cache files from linting